### PR TITLE
Fix compilation errors when using C++11

### DIFF
--- a/search16.cc
+++ b/search16.cc
@@ -97,16 +97,16 @@ void dprofile_dump16(WORD * dprofile)
   "        xorq    %%r11, %%r11            \n" 
 
 #define ONESTEP(H, N, F, V)			\
-  "        paddsw  "V"(%%rax), "H"         \n"	\
-  "        pmaxsw  "F", "H"                \n"	\
-  "        pmaxsw  %%xmm12, "H"            \n"	\
-  "        pmaxsw  "H", %%xmm13            \n"	\
-  "        psubsw  %%xmm15, "F"            \n"	\
+  "        paddsw  " V"(%%rax), " H"         \n"	\
+  "        pmaxsw  " F", " H"                \n"	\
+  "        pmaxsw  %%xmm12, " H"            \n"	\
+  "        pmaxsw  " H", %%xmm13            \n"	\
+  "        psubsw  %%xmm15, " F"            \n"	\
   "        psubsw  %%xmm15, %%xmm12        \n"	\
-  "        movdqa  "H", "N"                \n"	\
-  "        psubsw  %%xmm14, "H"            \n"	\
-  "        pmaxsw  "H", %%xmm12            \n"	\
-  "        pmaxsw  "H", "F"                \n"	
+  "        movdqa  " H", " N"                \n"	\
+  "        psubsw  %%xmm14, " H"            \n"	\
+  "        pmaxsw  " H", %%xmm12            \n"	\
+  "        pmaxsw  " H", " F"                \n"	
 
 inline void donormal16(volatile __m128i * Sm,  /* r9  */
 		       __m128i * hep, /* rdi */

--- a/search16s.cc
+++ b/search16s.cc
@@ -91,16 +91,16 @@ void dprofile_dump16s(WORD * dprofile)
   "        xorq    %%r11, %%r11     \n" 
 
 #define ONESTEP(H, N, F, V)		\
-  "        paddsw  "V"(%%rax), "H"  \n"	\
-  "        pmaxsw  "F", "H"         \n"	\
-  "        pmaxsw  %%xmm12, "H"     \n"	\
-  "        pmaxsw  "H", %%xmm13     \n"	\
-  "        psubsw  %%xmm15, "F"     \n"	\
+  "        paddsw  " V"(%%rax), " H"  \n"	\
+  "        pmaxsw  " F", " H"         \n"	\
+  "        pmaxsw  %%xmm12, " H"     \n"	\
+  "        pmaxsw  " H", %%xmm13     \n"	\
+  "        psubsw  %%xmm15, " F"     \n"	\
   "        psubsw  %%xmm15, %%xmm12 \n"	\
-  "        movdqa  "H", "N"         \n"	\
-  "        psubsw  %%xmm14, "H"     \n"	\
-  "        pmaxsw  "H", %%xmm12     \n"	\
-  "        pmaxsw  "H", "F"         \n"	
+  "        movdqa  " H", " N"         \n"	\
+  "        psubsw  %%xmm14, " H"     \n"	\
+  "        pmaxsw  " H", %%xmm12     \n"	\
+  "        pmaxsw  " H", " F"         \n"	
 
 
 inline void donormal16s(volatile __m128i * Sm,  /* r9  */

--- a/search7.cc
+++ b/search7.cc
@@ -583,16 +583,16 @@ void dseq_dump7(BYTE * dseq)
   "        xorq    %%r11, %%r11     \n"
 
 #define ONESTEP(H, N, F, V)				\
-  "        paddsb  "V"(%%rax), "H"  \n"			\
-  "        pmaxub  "F", "H"         \n"			\
-  "        pmaxub  %%xmm12, "H"     \n"			\
-  "        pmaxub  "H", %%xmm13     \n"			\
-  "        psubsb  %%xmm15, "F"     \n"			\
+  "        paddsb  " V"(%%rax), " H"  \n"			\
+  "        pmaxub  " F", " H"         \n"			\
+  "        pmaxub  %%xmm12, " H"     \n"			\
+  "        pmaxub  " H", %%xmm13     \n"			\
+  "        psubsb  %%xmm15, " F"     \n"			\
   "        psubsb  %%xmm15, %%xmm12 \n"			\
-  "        movdqa  "H", "N"         \n"			\
-  "        psubsb  %%xmm14, "H"     \n"			\
-  "        pmaxub  "H", %%xmm12     \n"			\
-  "        pmaxub  "H", "F"         \n"
+  "        movdqa  " H", " N"         \n"			\
+  "        psubsb  %%xmm14, " H"     \n"			\
+  "        pmaxub  " H", %%xmm12     \n"			\
+  "        pmaxub  " H", " F"         \n"
 
 inline void donormal7(__m128i * Sm,
 		      __m128i * hep,


### PR DESCRIPTION
C++11 requires a space between literal and identifier