### PR TITLE
Show all descriptions and alignments with maximum score

### DIFF
--- a/hits.cc
+++ b/hits.cc
@@ -1986,7 +1986,7 @@ void hits_show_end(long view)
   }
 }
 
-void hits_show(long view, long show_gis)
+void hits_show(long view, long show_gis, long show_best)
 {
   // compute number of hits and alignments to actually show
 
@@ -2002,7 +2002,18 @@ void hits_show(long view, long show_gis)
     showalignments = hits_count;
   else
     showalignments = opt_alignments;
-  
+
+  if (show_best > 0)
+  {
+    long high_score = hits_list[0].score;
+    long show_best_end = 0;
+    while (((show_best_end+1) < hits_count) && (high_score == hits_list[(show_best_end+1)].score))
+      show_best_end++;
+    show_best_end++;
+    showhits = show_best_end;
+    showalignments = show_best_end;
+  }
+
   struct db_thread_s * t = db_thread_create();
 
   if(view == 0)

--- a/hits.cc
+++ b/hits.cc
@@ -34,6 +34,7 @@ long obvious;
 
 long opt_descriptions;
 long opt_alignments;
+long opt_show_best;
 
 /* parameters for bit scores and expect values */
 
@@ -189,7 +190,26 @@ void hits_enter(long seqno, long score, long qstrand, long qframe,
 			 ((score == hits_list[place-1].score) && 
 			  (seqno > hits_list[place-1].seqno))))
     place--;
-  
+
+  long Nbest = 1;
+  if (place > 0)
+  {
+    if (score < hits_list[place-1].score)
+      Nbest++;
+    
+    for (long j=(place-1); j>0; j--)
+    {
+      if (hits_list[j].score < hits_list[j-1].score)
+        Nbest++;
+    }
+  }
+
+  if (Nbest > opt_show_best)
+  {
+    pthread_mutex_unlock(&hitsmutex);
+    return;
+  }
+
   // move entries down
   
   long move = (hits_count < keephits ? hits_count : keephits - 1) - place;
@@ -280,10 +300,11 @@ void hits_enter_align_string(long i, char * align, long align_len)
   //  hits_list[i].alignment[align_len] = 0;
 }
 
-void hits_init(long descriptions, long alignments, long minscore, long maxscore, double minexpect, double expect, int show_nostats)
+void hits_init(long descriptions, long alignments, long show_best, long minscore, long maxscore, double minexpect, double expect, int show_nostats)
 {
   opt_descriptions = descriptions;
   opt_alignments = alignments;
+  opt_show_best = show_best;
   keephits = descriptions > alignments ? descriptions : alignments;
   
   long maxhits = db_getseqcount_masked();
@@ -1986,7 +2007,7 @@ void hits_show_end(long view)
   }
 }
 
-void hits_show(long view, long show_gis, long show_best)
+void hits_show(long view, long show_gis)
 {
   // compute number of hits and alignments to actually show
 
@@ -2003,24 +2024,24 @@ void hits_show(long view, long show_gis, long show_best)
   else
     showalignments = opt_alignments;
 
-  if (show_best > 0)
+  long Nbest = 1;
+  long place = 1;
+  while (place < hits_count)
   {
-    long high_score = hits_list[0].score;
-    long show_best_end = 0;
-    while (((show_best_end+1) < hits_count) && (high_score == hits_list[(show_best_end+1)].score))
-      show_best_end++;
-    show_best_end++;
-    if (hits_count > 0)
-    {
-      showhits = show_best_end;
-      showalignments = show_best_end;      
-  } else
-    {
-      showhits = 0;
-      showalignments = 0;  
-    }
+    if (hits_list[place-1].score > hits_list[place].score)
+      Nbest++;
 
+    if (Nbest <= opt_show_best)
+      place++;
+    else
+      break;
   }
+
+  if (showhits > place)
+    showhits = place;
+  
+  if (showalignments > place)
+    showalignments = place;
 
   struct db_thread_s * t = db_thread_create();
 

--- a/hits.cc
+++ b/hits.cc
@@ -2010,8 +2010,16 @@ void hits_show(long view, long show_gis, long show_best)
     while (((show_best_end+1) < hits_count) && (high_score == hits_list[(show_best_end+1)].score))
       show_best_end++;
     show_best_end++;
-    showhits = show_best_end;
-    showalignments = show_best_end;
+    if (hits_count > 0)
+    {
+      showhits = show_best_end;
+      showalignments = show_best_end;      
+  } else
+    {
+      showhits = 0;
+      showalignments = 0;  
+    }
+
   }
 
   struct db_thread_s * t = db_thread_create();

--- a/swipe.cc
+++ b/swipe.cc
@@ -64,6 +64,7 @@ double expect;
 double minexpect;
 long minscore;
 long maxscore;
+long show_best;
 long alignments;
 long maxmatches;
 long gapopen;
@@ -796,6 +797,7 @@ void args_usage()
   fprintf(out, "  -G, --gapopen=NUM          gap open penalty (11)\n");
   fprintf(out, "  -E, --gapextend=NUM        gap extension penalty (1)\n");
   fprintf(out, "  -v, --num_descriptions=NUM sequence descriptions to show (250)\n");
+  fprintf(out, "  -B, --show_best=NUM        only show highest scoring sequences (0=no)\n");
   fprintf(out, "  -b, --num_alignments=NUM   sequence alignments to show (100)\n");
   fprintf(out, "  -e, --evalue=REAL          maximum expect value of sequences to show (10.0)\n");
   fprintf(out, "  -k, --minevalue=REAL       minimum expect value of sequences to show (0.0)\n");
@@ -856,7 +858,7 @@ void args_init(int argc, char **argv)
   progname = argv[0];
 
   opterr = 1;
-  char short_options[] = "d:i:M:q:r:G:E:S:v:b:c:u:e:k:a:m:p:x:C:Q:D:F:K:N:o:z:IHh";
+  char short_options[] = "d:i:M:q:r:G:E:S:v:B:b:c:u:e:k:a:m:p:x:C:Q:D:F:K:N:o:z:IHh";
 
   static struct option long_options[] =
   {
@@ -869,6 +871,7 @@ void args_init(int argc, char **argv)
     {"gapextend",        required_argument, NULL, 'E' },
     {"strand",           required_argument, NULL, 'S' },
     {"num_descriptions", required_argument, NULL, 'v' },
+    {"show_best",        required_argument, NULL, 'B' },
     {"num_alignments",   required_argument, NULL, 'b' },
     {"min_score",        required_argument, NULL, 'c' },
     {"max_score",        required_argument, NULL, 'u' },
@@ -907,7 +910,12 @@ void args_init(int argc, char **argv)
 	  /* threads */
 	  threads = atol(optarg);
 	  break;
-	  
+    
+  case 'B':
+    /* show best */
+    show_best = atol(optarg);
+    break;
+    
 	case 'b':
 	  /* alignments */
 	  alignments = atol(optarg);
@@ -2147,7 +2155,7 @@ void master(int size)
   fprintf(out, "Showing hits.\n");
 #endif
 
-  hits_show(view, show_gis);
+  hits_show(view, show_gis, show_best);
   
 #ifdef DEBUG
   fprintf(out, "Shown hits.\n");
@@ -2500,7 +2508,7 @@ void work()
   //  if (view == 0)
   //    clock_stop(&ti);
 
-  hits_show(view, show_gis);
+  hits_show(view, show_gis, show_best);
   hits_exit();
 }
 

--- a/swipe.cc
+++ b/swipe.cc
@@ -28,6 +28,7 @@
 /* ARGUMENTS AND THEIR DEFAULTS */
 
 #define DEFAULT_MAXMATCHES 250
+#define DEFAULT_SHOW_BEST 250
 #define DEFAULT_ALIGNMENTS 100
 #define DEFAULT_MINSCORE 1
 #define DEFAULT_MAXSCORE (LONG_MAX)
@@ -740,6 +741,7 @@ void args_show()
       fprintf(out, "Min score shown:   %ld\n", minscore);
       fprintf(out, "Max matches shown: %ld\n", maxmatches);
       fprintf(out, "Alignments shown:  %ld\n", alignments);
+      fprintf(out, "Best scores shown: %ld\n", show_best);
       fprintf(out, "Show gi's:         %ld\n", show_gis);
       fprintf(out, "Show taxid's:      %ld\n", show_taxid);
       fprintf(out, "Threads:           %ld\n", threads);
@@ -797,7 +799,7 @@ void args_usage()
   fprintf(out, "  -G, --gapopen=NUM          gap open penalty (11)\n");
   fprintf(out, "  -E, --gapextend=NUM        gap extension penalty (1)\n");
   fprintf(out, "  -v, --num_descriptions=NUM sequence descriptions to show (250)\n");
-  fprintf(out, "  -B, --show_best=NUM        only show highest scoring sequences (0=no)\n");
+  fprintf(out, "  -B, --show_best=NUM        number of different scoring sequences to show (250)\n");
   fprintf(out, "  -b, --num_alignments=NUM   sequence alignments to show (100)\n");
   fprintf(out, "  -e, --evalue=REAL          maximum expect value of sequences to show (10.0)\n");
   fprintf(out, "  -k, --minevalue=REAL       minimum expect value of sequences to show (0.0)\n");
@@ -838,6 +840,7 @@ void args_init(int argc, char **argv)
   maxscore = DEFAULT_MAXSCORE;
   maxmatches = DEFAULT_MAXMATCHES;
   alignments = DEFAULT_ALIGNMENTS;
+  show_best = DEFAULT_SHOW_BEST;
   threads = DEFAULT_THREADS;
   view = DEFAULT_VIEW;
   symtype = DEFAULT_SYMTYPE;
@@ -1165,6 +1168,9 @@ void args_init(int argc, char **argv)
 
   if ((dump<0) || (dump>2))
     fatal("Illegal dump mode.");
+
+  if (maxmatches < show_best)
+    maxmatches = show_best;
   
   translate_init(query_gencode, db_gencode);
 }
@@ -1853,7 +1859,7 @@ void master(int size)
 
   /* init */
   
-  hits_init(maxmatches, alignments, minscore, maxscore, minexpect, expect, view==0);
+  hits_init(maxmatches, alignments, show_best, minscore, maxscore, minexpect, expect, view==0);
 
   prepare_search(size-1);
 
@@ -2155,7 +2161,7 @@ void master(int size)
   fprintf(out, "Showing hits.\n");
 #endif
 
-  hits_show(view, show_gis, show_best);
+  hits_show(view, show_gis);
   
 #ifdef DEBUG
   fprintf(out, "Shown hits.\n");
@@ -2187,7 +2193,7 @@ void slave(int rank, int size)
   //  fprintf(out, "Node %d: SSE2: %ld SSSE3: %ld\n", rank, cpu_feature_sse2, cpu_feature_ssse3);
   //  fprintf(out, "This is slave no %d.\n", rank);
 
-  hits_init(maxmatches, alignments, minscore, maxscore, minexpect, expect, 0);
+  hits_init(maxmatches, alignments, show_best, minscore, maxscore, minexpect, expect, 0);
 
   prepare_search(size-1);
 
@@ -2444,7 +2450,7 @@ void slave(int rank, int size)
 void work()
 {
   args_show();
-  hits_init(maxmatches, alignments, minscore, maxscore, minexpect, expect, view==0);
+  hits_init(maxmatches, alignments, show_best, minscore, maxscore, minexpect, expect, view==0);
 
   compute7 = 0;
   compute16 = 0;
@@ -2508,7 +2514,7 @@ void work()
   //  if (view == 0)
   //    clock_stop(&ti);
 
-  hits_show(view, show_gis, show_best);
+  hits_show(view, show_gis);
   hits_exit();
 }
 

--- a/swipe.h
+++ b/swipe.h
@@ -111,6 +111,7 @@ extern long maxmatches;
 extern long threads;
 extern const char * databasename;
 extern long alignments;
+extern long show_best;
 extern long queryno;
 extern long compute7;
 extern long show_taxid;
@@ -346,7 +347,7 @@ void db_getsequence(struct db_thread_s * t, long seqno, long strand, long frame,
 void db_getheader(struct db_thread_s * t, long seqno, char ** address, 
 		  long * length);
 
-void hits_init(long descriptions, long alignments, long minscore, 
+void hits_init(long descriptions, long alignments, long show_best, long minscore, 
 	       long maxscore, double minexpect, double expect, int show_nostats);
 void hits_enter(long seqno, long score, long qstrand, long qframe,
 		long dstrand, long dframe, long align_hint, long bestq);
@@ -355,7 +356,7 @@ long hits_getcount();
 void hits_align(struct db_thread_s * t, long i);
 void hits_show_begin(long view);
 void hits_show_end(long view);
-void hits_show(long view, long show_gis, long show_best);
+void hits_show(long view, long show_gis);
 void hits_empty();
 void hits_exit();
 void hits_gethit(long i, long * seqno, long * score, 

--- a/swipe.h
+++ b/swipe.h
@@ -355,7 +355,7 @@ long hits_getcount();
 void hits_align(struct db_thread_s * t, long i);
 void hits_show_begin(long view);
 void hits_show_end(long view);
-void hits_show(long view, long show_gis);
+void hits_show(long view, long show_gis, long show_best);
 void hits_empty();
 void hits_exit();
 void hits_gethit(long i, long * seqno, long * score, 


### PR DESCRIPTION
Clunky way of solving the request that I wrote about in this issue:
https://github.com/torognes/swipe/issues/37

Not suggesting this as the actual solution, but rather showing it so that it is clear what I am referring to in the issue. In a better solution the `show_best` option should probably be a boolean or yes/no and there is probably a more intelligent way of implementing it such that `showhits` and `showalignments ` are not forced to be the same.